### PR TITLE
[Bugfix] instance.UI.setActiveLeftPanel not working in modular UI

### DIFF
--- a/src/helpers/isDataElementLeftPanel.js
+++ b/src/helpers/isDataElementLeftPanel.js
@@ -8,7 +8,7 @@ export const getLeftPanelDataElements = (state) => {
   const { customizableUI } = featureFlags;
 
   if (customizableUI) {
-    return state.viewer.genericPanels.filter((item) => item.location === PLACEMENT.LEFT);
+    return state.viewer.genericPanels.filter((item) => item.location === PLACEMENT.LEFT).map((item) => item.dataElement);
   }
 
   const defaultLeftPanels = [


### PR DESCRIPTION
- Fixes #1069 


Concrete data-element identifier like "thumbnailsPanel" are obviously not included in a collection that consists of objects that have the form

```js
{
  dataElement ...
  location ...
  render: ...
}
```

So mapping these down to their dataElement property should make the inclusion check work again :)

I ran `npm run lint` before but because of just a single changed line I think there isn't much work to be done here 😄 